### PR TITLE
Add text search config

### DIFF
--- a/config_sample.py
+++ b/config_sample.py
@@ -1,9 +1,12 @@
-SECRET_KEY = '<KEY>' # As for now, OokCatalog does not make use of any cookie
+SECRET_KEY = "<KEY>"  # As for now, OokCatalog does not make use of any cookie
 DATABASE = {
-            "HOST": "localhost",
-            "PORT": "5432",
-            "DBNAME": "ookcatalog",
-            "USER": "ookcatalog",
-            "PASSWORD": "password",
-        }
+    "HOST": "localhost",
+    "PORT": "5432",
+    "DBNAME": "ookcatalog",
+    "USER": "ookcatalog",
+    "PASSWORD": "password",
+}
 DATABASE_TITLE = "BDU"
+# Language passed to PostgreSQL for full text search. Needed so it knows how to interpret both the search requests and
+# the documents.
+TEXT_SEARCH_LANG = "french"

--- a/ookcatalog/__init__.py
+++ b/ookcatalog/__init__.py
@@ -3,7 +3,8 @@ from flask_babel import Babel
 
 
 def get_locale():
-    return request.accept_languages.best_match(['en', 'fr'])
+    return request.accept_languages.best_match(["en", "fr"])
+
 
 def create_app(test_config=None):
     # Create the app
@@ -18,11 +19,12 @@ def create_app(test_config=None):
             "USER": "ookcatalog",
             "PASSWORD": "ookcatalog_pass",
         },
+        TEXT_SEARCH_LANG="english",
     )
 
     if test_config is None:
         # load the instance config, if it exists, when not testing
-        app.config.from_envvar('OOKCATALOG_SETTINGS')
+        app.config.from_envvar("OOKCATALOG_SETTINGS")
     else:
         # load the test config if passed in
         app.config.from_mapping(test_config)

--- a/ookcatalog/db.py
+++ b/ookcatalog/db.py
@@ -136,7 +136,10 @@ def db_search(db, query: str):
             ORDER BY rank DESC
             LIMIT 20;
             """,
-            {'query': query, 'text_search_lang': current_app.config['TEXT_SEARCH_LANG']},
+            {
+                "query": query,
+                "text_search_lang": current_app.config["TEXT_SEARCH_LANG"],
+            },
         )
         # Fetching the result
         search_results = cur.fetchall()


### PR DESCRIPTION
Closes #4 

Allows configuring the text search language so PostgreSQL correctly interprets the request.