### PR TITLE
Warning for data updates

### DIFF
--- a/ookcatalog/__init__.py
+++ b/ookcatalog/__init__.py
@@ -1,9 +1,12 @@
 from flask import Flask, request
 from flask_babel import Babel
+from locale import getlocale
 
 
 def get_locale():
-    return request.accept_languages.best_match(["en", "fr"])
+    if request:
+        return request.accept_languages.best_match(["en", "fr"])
+    return getlocale()[0]
 
 
 def create_app(test_config=None):
@@ -38,8 +41,9 @@ def create_app(test_config=None):
     db.init_app(app)
 
     # Register ookcatalog consulting views
-    from . import catalog
+    from . import catalog, cron
 
     app.register_blueprint(catalog.bp)
+    app.register_blueprint(cron.bp)
 
     return app

--- a/ookcatalog/cron.py
+++ b/ookcatalog/cron.py
@@ -1,0 +1,57 @@
+from flask import Blueprint
+from ookcatalog.db import (
+    get_db,
+    db_tables_updating,
+)
+from datetime import date, timedelta
+from flask_babel import gettext as _
+
+bp = Blueprint("cron", __name__)
+
+
+@bp.cli.command("tables-updating")
+def tables_updating():
+    today = date.today()  # Getting today’s date
+    tables_updating = {}  # Container for results
+    db = get_db()
+    tables_updating["this_month"] = db_tables_updating(
+        db, today.month
+    )  # Getting this month updates
+    tables_updating_text = _("# This month updates:")  # Text result
+    for table in tables_updating["this_month"]:
+        # Putting table schema and name in the text result
+        tables_updating_text += "\n{table}".format(
+            table=f"{table['table_schema']}.{table['table_name']}"
+        )
+
+    if today.day <= 10:  # If in first part of the month
+        last_month = (
+            today.replace(day=1) - timedelta(days=1)
+        ).month  # Getting previous month
+        tables_updating["last_month"] = db_tables_updating(
+            db, last_month
+        )  # Getting previous updates
+        text = _("# Last month updates:")  # Temporary text
+        for table in tables_updating["last_month"]:
+            text += "\n{table}".format(
+                table=f"{table['table_schema']}.{table['table_name']}"
+            )
+        tables_updating_text = (
+            text + "\n\n" + tables_updating_text
+        )  # Putting temporary text in result text
+
+    if today.day > 20:  # If in third part of the month
+        next_month = (
+            today.replace(day=25) + timedelta(days=10)
+        ).month  # Getting next month
+        tables_updating["next_month"] = db_tables_updating(
+            db, next_month
+        )  # Getting next month updates
+        text = _("# Next month updates:")  # Temporary text
+        for table in tables_updating["next_month"]:
+            text += "\n{table}".format(
+                table=f"{table['table_schema']}.{table['table_name']}"
+            )
+        tables_updating_text += "\n\n" + text  # Putting temporary text in result text
+
+    print(tables_updating_text)  # Printing the result as this is a CLI command

--- a/ookcatalog/translations/fr/LC_MESSAGES/messages.po
+++ b/ookcatalog/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-21 21:10+0100\n"
+"POT-Creation-Date: 2024-03-22 22:46+0100\n"
 "PO-Revision-Date: 2024-03-21 21:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -17,6 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
+
+#: ookcatalog/cron.py:20
+msgid "# This month updates:"
+msgstr "# Mises à jour du mois :"
+
+#: ookcatalog/cron.py:34
+msgid "# Last month updates:"
+msgstr "# Mises à jour du mois dernier :"
+
+#: ookcatalog/cron.py:50
+msgid "# Next month updates:"
+msgstr "# Mises à jour du mois prochain :"
 
 #: ookcatalog/templates/home.html:2
 msgid "Schemas"


### PR DESCRIPTION
Closes #2 

Adds a CLI command allowing to get tables updating on this month. Based on the day of the month, it will include a recall of the updates of the previous month (roughly on the first third of the month), or a warning of the updates coming on the following month (roughly on the last third of the month).