### PR TITLE
Tables missing comments command

### DIFF
--- a/ookcatalog/commands.py
+++ b/ookcatalog/commands.py
@@ -3,6 +3,9 @@ from ookcatalog.db import (
     get_db,
     db_tables_updating,
     db_catalog_retrieve_tables,
+    db_tables_missing_comment,
+    db_tables_with_columns_missing_comment,
+    db_tables_missing_ookcatalog_details,
 )
 from datetime import date, timedelta
 from flask_babel import gettext as _
@@ -64,4 +67,18 @@ def update_tables_catalog():
     tables_inserted = db_catalog_retrieve_tables(db)
     print(_("# Tables inserted in public.ookcatalog:"))
     for table in tables_inserted:
+        print(f"{table['table_schema']}.{table['table_name']}")
+
+
+@bp.cli.command("tables-missing-comments")
+def get_tables_missing_comments():
+    db = get_db()
+    print(_("# Tables missing comments:"))
+    for table in db_tables_missing_comment(db):
+        print(f"{table['table_schema']}.{table['table_name']}")
+    print(_("\n# Tables with column missing comments:"))
+    for table in db_tables_with_columns_missing_comment(db):
+        print(f"{table['table_schema']}.{table['table_name']}")
+    print(_("\n# Tables missing OokCatalog details:"))
+    for table in db_tables_missing_ookcatalog_details(db):
         print(f"{table['table_schema']}.{table['table_name']}")

--- a/ookcatalog/translations/fr/LC_MESSAGES/messages.po
+++ b/ookcatalog/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-22 22:46+0100\n"
+"POT-Creation-Date: 2024-03-24 15:35+0100\n"
 "PO-Revision-Date: 2024-03-21 21:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -18,17 +18,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: ookcatalog/cron.py:20
+#: ookcatalog/commands.py:24
 msgid "# This month updates:"
 msgstr "# Mises à jour du mois :"
 
-#: ookcatalog/cron.py:34
+#: ookcatalog/commands.py:38
 msgid "# Last month updates:"
 msgstr "# Mises à jour du mois dernier :"
 
-#: ookcatalog/cron.py:50
+#: ookcatalog/commands.py:54
 msgid "# Next month updates:"
 msgstr "# Mises à jour du mois prochain :"
+
+#: ookcatalog/commands.py:68
+msgid "# Tables inserted in public.ookcatalog:"
+msgstr "# Tables ajoutées à public.ookcatalog :"
+
+#: ookcatalog/commands.py:76
+msgid "# Tables missing comments:"
+msgstr "# Tables sans commentaire :"
+
+#: ookcatalog/commands.py:79
+msgid ""
+"\n"
+"# Tables with column missing comments:"
+msgstr ""
+"\n"
+"# Tables avec des colonnes sans commentaire :"
+
+#: ookcatalog/commands.py:82
+msgid ""
+"\n"
+"# Tables missing OokCatalog details:"
+msgstr ""
+"\n"
+"# Tables avec des détails OokCatalog manquants :"
 
 #: ookcatalog/templates/home.html:2
 msgid "Schemas"


### PR DESCRIPTION
Refers to #3 

Although it doesn’t add a visual indicator, it allows to get the full list of tables missing some description (either a table comment, a column comment, or public.ookcatalog specific detail).